### PR TITLE
Updated install lazy.nvim section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ Install using [`lazy.nvim`](https://github.com/folke/lazy.nvim):
 require("lazy").setup({
     {
         "kdheepak/lazygit.nvim",
+    	cmd = {
+    		"LazyGit",
+    		"LazyGitConfig",
+    		"LazyGitCurrentFile",
+    		"LazyGitFilter",
+    		"LazyGitFilterCurrentFile",
+    	},
         -- optional for floating window border decoration
         dependencies = {
             "nvim-lua/plenary.nvim",


### PR DESCRIPTION
When using lazy.nvim, the Plugin should only load now, if one of its functions is called.